### PR TITLE
Makefile: Enforce ld.lld as a default linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ HOSTCXX      = g++
 HOSTCFLAGS   := -Wall -Wmissing-prototypes -Wstrict-prototypes -O2 \
 		-fomit-frame-pointer -std=gnu89 -pipe $(HOST_LFS_CFLAGS)
 HOSTCXXFLAGS := -O2 $(HOST_LFS_CFLAGS)
-HOSTLDFLAGS  := $(HOST_LFS_LDFLAGS)
+HOSTLDFLAGS  += $(HOST_LFS_LDFLAGS)
 HOST_LOADLIBES := $(HOST_LFS_LIBS)
 
 # Make variables (CC, etc...)
@@ -378,6 +378,8 @@ CPP		= $(CC) -E
 AR		= llvm-ar
 NM		= llvm-nm
 STRIP		= llvm-strip
+HOSTLDFLAGS	+= -fuse-ld=lld
+HOSTCFLAGS 	+= -fuse-ld=lld
 OBJCOPY		= llvm-objcopy
 OBJDUMP		= llvm-objdump
 AWK		= awk

--- a/arch/arm64/boot/dts/qcom/sm8150-gpu-v2.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8150-gpu-v2.dtsi
@@ -16,32 +16,32 @@
 
 		opp-675000000 {
 			opp-hz = /bits/ 64 <675000000>;
-			opp-microvolt = <RPMH_REGULATOR_LEVEL_NOM_L1>;
+			opp-microvolt = <RPMH_REGULATOR_LEVEL_NOM>;
 		};
 
 		opp-585000000 {
 			opp-hz = /bits/ 64 <585000000>;
-			opp-microvolt = <RPMH_REGULATOR_LEVEL_NOM>;
+			opp-microvolt = <RPMH_REGULATOR_LEVEL_SVS_L2>;
 		};
 
 		opp-499200000 {
 			opp-hz = /bits/ 64 <499200000>;
-			opp-microvolt = <RPMH_REGULATOR_LEVEL_SVS_L2>;
+			opp-microvolt = <RPMH_REGULATOR_LEVEL_SVS_L1>;
 		};
 
 		opp-427000000 {
 			opp-hz = /bits/ 64 <427000000>;
-			opp-microvolt = <RPMH_REGULATOR_LEVEL_SVS_L1>;
+			opp-microvolt = <RPMH_REGULATOR_LEVEL_SVS>;
 		};
 
 		opp-345000000 {
 			opp-hz = /bits/ 64 <345000000>;
-			opp-microvolt = <RPMH_REGULATOR_LEVEL_SVS>;
+			opp-microvolt = <RPMH_REGULATOR_LEVEL_LOW_SVS>;
 		};
 
 		opp-257000000 {
 			opp-hz = /bits/ 64 <257000000>;
-			opp-microvolt = <RPMH_REGULATOR_LEVEL_LOW_SVS>;
+			opp-microvolt = <RPMH_REGULATOR_LEVEL_MIN_SVS>;
 		};
 	};
 };

--- a/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_display.c
@@ -235,116 +235,117 @@ int dsi_display_set_backlight(struct drm_connector *connector,
 
 	if (dsi_display->panel->hw_type == DSI_PANEL_SAMSUNG_S6E3FC2X01) {
 		if (bl_lvl != 0 && panel->bl_config.bl_level == 0) {
+			if (panel->naive_display_loading_effect_mode) {
+				pr_debug("Send DSI_CMD_LOADING_EFFECT_ON cmds\n");
+				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_EFFECT_ON);
+			}
 			if (panel->naive_display_p3_mode) {
-				mdelay(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_P3_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_P3_ON);
 			}
 			if (panel->naive_display_wide_color_mode) {
-				mdelay(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_WIDE_COLOR_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_WIDE_COLOR_ON);
 			}
 			if (panel->naive_display_srgb_color_mode) {
-				mdelay(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_SRGB_COLOR_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_SRGB_COLOR_ON);
 			}
+			if (panel->night_mode) {
+				mdelay(100);
+				pr_debug("Send DSI_CMD_SET_NIGHT_ON cmds\n");
+				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NIGHT_ON);
+			}
 			if (panel->naive_display_customer_srgb_mode) {
+				mdelay(100);
 				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_RGB_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_RGB_ON);
-			} else {
-				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_RGB_OFF cmds\n");
-				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_RGB_OFF);
 			}
 			if (panel->naive_display_customer_p3_mode) {
+				mdelay(100);
 				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_P3_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_P3_ON);
-			} else {
-				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_P3_OFF cmds\n");
-				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_P3_OFF);
 			}
 		}
 	}
 
 	if (dsi_display->panel->hw_type == DSI_PANEL_SAMSUNG_S6E3HC2) {
 		if (bl_lvl != 0 && panel->bl_config.bl_level == 0) {
+			if (panel->naive_display_loading_effect_mode) {
+				pr_debug("Send DSI_CMD_LOADING_EFFECT_ON cmds\n");
+				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_EFFECT_ON);
+			}
 			if (panel->naive_display_p3_mode) {
-				mdelay(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_P3_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_P3_ON);
 			}
 			if (panel->naive_display_wide_color_mode) {
-				mdelay(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_WIDE_COLOR_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_WIDE_COLOR_ON);
 			}
 			if (panel->naive_display_srgb_color_mode) {
-				mdelay(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_SRGB_COLOR_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_SRGB_COLOR_ON);
 			}
-			if (panel->naive_display_loading_effect_mode) {
-				pr_debug("Send DSI_CMD_LOADING_EFFECT_ON cmds\n");
-				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_EFFECT_ON);
-			} else {
-				pr_debug("Send DSI_CMD_LOADING_EFFECT_OFF cmds\n");
-				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_EFFECT_OFF);
+			if (panel->night_mode) {
+				mdelay(100);
+				pr_debug("Send DSI_CMD_SET_NIGHT_ON cmds\n");
+				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NIGHT_ON);
 			}
 			if (panel->naive_display_customer_srgb_mode) {
+				mdelay(100);
 				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_RGB_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_RGB_ON);
-			} else {
-				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_RGB_OFF cmds\n");
-				//rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_RGB_OFF);
 			}
 			if (panel->naive_display_customer_p3_mode) {
+				mdelay(100);
 				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_P3_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_P3_ON);
-			} else {
-				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_P3_OFF cmds\n");
-				//rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_P3_OFF);
 			}
 		}
 	}
 
 	if (dsi_display->panel->hw_type == DSI_PANEL_SAMSUNG_SOFEF03F_M) {
 		if (bl_lvl != 0 && panel->bl_config.bl_level == 0) {
+			if (panel->naive_display_loading_effect_mode) {
+				pr_debug("Send DSI_CMD_LOADING_EFFECT_ON cmds\n");
+				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_EFFECT_ON);
+			}
 			if (panel->naive_display_p3_mode) {
-				msleep(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_P3_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_P3_ON);
 			}
 			if (panel->naive_display_wide_color_mode) {
-				msleep(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_WIDE_COLOR_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_WIDE_COLOR_ON);
 			}
 			if (panel->naive_display_srgb_color_mode) {
-				msleep(20);
+				mdelay(100);
 				pr_debug("Send DSI_CMD_SET_NATIVE_DISPLAY_SRGB_COLOR_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NATIVE_DISPLAY_SRGB_COLOR_ON);
 			}
-			if (panel->naive_display_loading_effect_mode) {
-				pr_debug("Send DSI_CMD_LOADING_EFFECT_ON cmds\n");
-				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_EFFECT_ON);
-			} else {
-				pr_debug("Send DSI_CMD_LOADING_EFFECT_OFF cmds\n");
-				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_EFFECT_OFF);
+			if (panel->night_mode) {
+				mdelay(100);
+				pr_debug("Send DSI_CMD_SET_NIGHT_ON cmds\n");
+				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_NIGHT_ON);
 			}
 			if (panel->naive_display_customer_srgb_mode) {
+				mdelay(100);
 				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_RGB_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_RGB_ON);
-			} else {
-				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_RGB_OFF cmds\n");
-				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_RGB_OFF);
 			}
 			if (panel->naive_display_customer_p3_mode) {
+				mdelay(100);
 				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_P3_ON cmds\n");
 				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_P3_ON);
-			} else {
-				pr_debug("Send DSI_CMD_LOADING_CUSTOMER_P3_OFF cmds\n");
-				rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_LOADING_CUSTOMER_P3_OFF);
 			}
 		}
 	}

--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -66,7 +66,7 @@ static void scm_disable_sdi(void);
  * There is no API from TZ to re-enable the registers.
  * So the SDI cannot be re-enabled when it already by-passed.
  */
-static int download_mode = 1;
+static int download_mode = 0;
 static bool force_warm_reboot = true;
 
 #ifdef CONFIG_QCOM_DLOAD_MODE


### PR DESCRIPTION
  GEN     ./Makefile
  HOSTCC  scripts/basic/fixdep
clang-14: error: unable to execute command: Executable "ld" doesn't exist!
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [scripts/Makefile.host:102: scripts/basic/fixdep] Error 1